### PR TITLE
Update XML MLB Current Season

### DIFF
--- a/XML MLB Current Season
+++ b/XML MLB Current Season
@@ -45,55 +45,212 @@ rootnode[[1]][[1]][[1]] %>% xmlAttrs(.)
 rootnode[[1]][[1]][[1]] %>% xmlGetAttr("des")
 rootnode[[1]][[1]][[2]] %>% xmlGetAttr("des")
 
-parseRoot <- function(mlbURL, item){
+
+
+# We begin by getting a count of innings in the game. By taking the sum of a logical testing comparing
+# the names of every toplevel node that is equal to "inning' gives us this count. It will mostly be
+# 9 innings, but there will often be exceptions...
+
+sum(names(rootnode) == "inning")
+
+# The result will set the parameters of our first loop, which will loop through each inning iteratively.
+# For the purposes of this endeavor, we will just be looking at the first inning, subset like this:
+
+rootnode[[1]]
+
+# Here, you can see the next level of nodes comprises of 'top' and 'bottom'
+
+names(rootnode[[1]])
+
+# That means this info is structured by inning and subsequently by the top or bottom of the inning. The
+# parameters here will setup the functioning of our second level loop, and, at first, I thought it best
+# to explicitly program this loop to iterate twice (1:2). However, on further examination, I realized
+# that it is possible for there to be only one 2nd level node, particularly occurring during a game 
+# ending after the top of the ninth inning. Thus, we'll have to program a count test to setup the 
+# parameters of our second level loop
+
+length(names(rootnode[[1]])) # N = 2, naturally
+
+# Let's look at the top and bottom of the first inning
+
+rootnode[[1]][[1]] # Top of first inning
+rootnode[[1]][[2]] # Bottom of first inning
+
+# Now, we'll need a third level loop to dive into each item within each subdivision of every inning. 
+# This is particularly important, because the number of items within each innings subdivision will vary. 
+# It will likely be a common 1-2-3 situation, with 3 batters up and out, like in the top of the first
+
+names(rootnode[[1]][[1]]) # 3 at-bats
+
+# However, there could be more than 3 batters, like in the top of the second:
+
+names(rootnode[[2]][[1]])
+
+# And there are also 'action' items, particularly substitutions, more commonly in the latter stages
+# of the game
+
+names(rootnode[[9]][[2]])
+
+# So, we'll need to get the count of items in this third level
+
+length(names(rootnode[[1]][[1]])) # There are 3 events in the top of the first
+length(names(rootnode[[1]][[2]])) # And 3 events in the bottom of the first
+
+# Now, there are a couple of things to not moving forward. If the the event is an 'atbat', then we need
+# to dive down one more level with another loop. Because our effort here is to get the result of every 
+# pitch, then we will need to get the length of items within each atbat. There is a node called 'pitch'
+# that contains this data. Obviously, there will be varying counts of pitches
+
+names(rootnode[[1]][[1]][[1]]) # 3 pitches to the first batter in the top of the first inning
+names(rootnode[[1]][[1]][[2]]) # 4 pitches to the second batter in the top of the first
+names(rootnode[[1]][[1]][[3]]) # 1 pitch to the third batter...
+
+# We can scrape the result of these by pulling the attribute 'des' from each pitch. Let's scrape this attribute
+# for every pitch to the first batter in the top of the first inning
+
+rootnode[[1]][[1]][[1]][[1]] %>% xmlGetAttr("des") # First pitch is a ball
+rootnode[[1]][[1]][[1]][[2]] %>% xmlGetAttr("des") # Second pitch is a foul
+rootnode[[1]][[1]][[1]][[3]] %>% xmlGetAttr("des") # Third pitch is hit, put into play, resulting in an out
+
+# So, we can pull pitch results by looping down through 4 levels of nodes, requiring 4 nested loops. However, 
+# the tricky part is that there is info needed in the third node level as well, that's the atbat level
+
+rootnode[[1]][[1]][[1]] %>% xmlAttrs(.)
+
+# There are a ton of attributes in the third level. Here's what we'll need to pull:
+
+# 1. num : This is the atbat number
+# 2. batter : This is a numeric code for the player at bat
+# 3. pitcher : This is the numeric code for the pitcher 
+# 4. des : this is a text description of the play
+# 5. event_num : This is an event number, will use similarly to Idx in retrosheets
+# 6. event : This is a simplified play result
+
+# Another complication: There can be more than one event attribute: look at this
+
+rootnode[[3]][[1]][[3]] %>% xmlAttrs(.)
+
+# In the third at bat during the top of the third, two things happen: A batter strikes out and a baserunner
+# is caught stealing second base. There is an attribute, 'event' for the strikeout, and a second attribute,
+# called 'event2' for the baserunner caught stealing. We will have to account for this, probably with regular
+# expressions.
+
+# Another thing to compensate for is that, in the third level, we'll need to do something different for action
+# items. Remember the ninth inning:
+
+rootnode[[9]][[2]] %>% names(.) # There are 3 actions and three atbats
+
+rootnode[[9]][[2]][[1]] # Defensive substitution
+rootnode[[9]][[2]][[2]] # Pitcher substitution
+rootnode[[9]][[2]][[6]] # Offensive substitution; pinch hitter
+
+# Pitcher subs should be regarded with little or no concern, since the next item in the iteration will have
+# the newly subbed pitcher's id number in the atbat. This should hold true for the offensive sub as well. 
+# However, we'll have to find a way to work in the defensive subs, so that the P1 through P9 in the defensive
+# position variables are correctly accounted for... My first thought is to have this parsing application process
+# these 'event' nodes separately from the 'atbat' nodes, working them into the processed data frame side effect
+# later on in the schema. I'll start with this in mind, but rework it later if I find it to be too arduous or
+# innefectual. Overall, it shouldnt be too difficult to rework in these actions because the event number works
+# iteratively, allowing us to know the order in which these third level nodes occur
+
+# So, with a focus on pulling just atbat data. Overall, the idea is that we need to pull 4th level pitch results and
+# adhere them to relevant data from the third level atbat attributes. We will practice this process on two test samples. 
+# The first will be the top of the first inning, containing only 3 atbats. The second test will be used to process atbats
+# and action items separately and well use a subset from the bottom of the ninth inning. Getting to these levels is pretty
+# simple, involving two nested loops (i and j) that loop, at the first level, through the innings and subsequently through 
+# the top and/or bottom of the inning
+
+test <- rootnode[[1]][[1]]
+test2 <- rootnode[[9]][[2]]
+
+# Syntax used to explore testing on test and test2 subsets has been omitted and the discovery derived from the work on these
+# two subsets has been implicated in the function, called parseMLB, below. This function takes in a url from a given game
+# in xml format and processes it into a data.table for which subsequent added values and processes are needed. 
+
+test <- "http://gd2.mlb.com/components/game/mlb/year_2017/month_08/day_09/gid_2017_08_09_lanmlb_arimlb_1/game_events.xml"
+
+parseMLB <- function(gameURL){
+
   
-  t1 <- xmlParse(mlbURL) %>% xmlRoot(.)
+  root <- xmlParse(file = gameURL) %>% xmlRoot(.)
   
-  n1 <- sum(names(t1) == "inning")
+  N1 <- sum(names(root) == "inning")
   
-  for(i in 1:n1){
+  PLAYS <- data.table("Val" = NA, "Var" = NA, "Idx" = 0)
+  PITCHES <- data.table("Val" = NA, "Var" = NA, "Idx" = 0)
+  
+  for(inning in 1:N1){
     
-    for(j in 1:2){
+    N2 <- names(root[[inning]]) %>% length(.)
+    
+    for(section in 1:N2){
       
-      n2 <- length(names(t1[[i]][[j]]))
+      N3 <- root[[inning]][[section]] %>% names(.) %>% length(.)
       
-      for(k in 1:n2){
+      for(action in 1:N3){
         
-        # here we could specify the attribute, passing it from an additional function argument,
-        # and having that pushed into an array with the previous loop parameters that can be
-        # later converted piecemeal
+        T1 <- root[[inning]][[section]][[action]]
+        eve_num <- T1 %>% xmlGetAttr("event_num") %>% as.numeric(.)
         
-        # i = 1
-        # j = 1
-        # 
+        T2 <- T1 %>% xmlAttrs(.) %>% data.frame(.)
+        T2$Var <- rownames(T2)
+        T2$Idx <- rep(eve_num, nrow(T2))
+        T2 <- data.table(T2) %>% setnames(., names(.), c("Val", "Var", "Idx"))
+        
+        PLAYS <- rbind(PLAYS, T2)
+        
+        if(xmlName(T1) == "atbat"){
+          
+          N4 <- length(names(T1))
+          
+          for(pitch in 1:N4){
+            
+            T3 <- root[[inning]][[section]][[action]][[pitch]]
+            
+            T3 <- T3 %>% xmlAttrs(.) %>% data.frame(.)
+            T3$Var <- rownames(T3)
+            T3$Idx <- rep(eve_num, nrow(T3))
+            T3 <- data.table(T3) %>% setnames(., names(.), c("Val", "Var", "Idx"))
+            
+            PITCHES <- rbind(PITCHES, T3)
+            
+            
+          }
+          
+        }
+        
       }
+      
       
     }
     
     
   }
   
-  return(n2)
+  PLAYS <- dcast(PLAYS, Idx ~ Var, value.var = "Val")
+  PLAYS <- PLAYS[Idx > 0]
+  PLAYS <- PLAYS[, Date := as.Date(substr(start_tfs_zulu, 1, 10))]
+  
+  omits <- c("away_team_runs", "b1", "b2", "b3", names(PLAYS)[grep("_es", names(PLAYS))], "home_team_runs", "pitch", "play_guid", 
+             "player", "rbi", "score", "start_tfs", "tfs", "tfs_zulu", "NA", "start_tfs_zulu")
+  
+  PLAYS <- PLAYS[, c(names(PLAYS) %in% omits == F), with = F]
+  
+  PITCHES <- PITCHES[Var %in% c("des")] %>% 
+    .[, Val := as.character(Val)] %>% 
+    .[, c("Idx", "Val"), with = F] %>% 
+    setnames(., "Val", "PitchResult")
+  
+  TX <- merge(PLAYS, PITCHES, by = "Idx", all.x = T)
+    
+  
+  return(TX)
   
 }
 
-parseRoot(gameURL)
 
-rootnode[[9]][[2]]
-
-
-
-
-https://www.stat.berkeley.edu/~statcur/Workshop2/Presentations/XML.pdf
-
-
-library(RJSONIO)
-
-gameURL2 <- "http://gd2.mlb.com/components/game/mlb/year_2017/month_08/day_09/gid_2017_08_09_lanmlb_arimlb_1/game_events.json"
-
-test2 <- RJSONIO::fromJSON(gameURL2)
-test2[['data']][['game']]
-
+temp <- parseMLB(test)
+print(temp)
 
 
 


### PR DESCRIPTION
Figured out a schema for scraping current season data from a given xml link from mlb. This needs some further work, but the bulk of what I was hoping to achieve is in the function parseMLB. We need to add some derived variables, bring in the retroIDs, and add counts and other variables. With a little more work, we should be able to create a dataset similar to what is pulled from retrosheets, stack them together so that we can have previous and current season data in a unified format. 

Another effort to take into consideration is how to run this application in bulk, processing multiple games both in a retrospective as well as ongoing sense. The hope is to have something that works daily for next year's season.